### PR TITLE
Add parse error require

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pseudocode",
-    "version": "0.1.0",
+    "version": "1.1.1",
     "author": {
         "name": "Tate Tian",
         "email": "tatetian@gmail.com",

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -79,6 +79,7 @@
  *
  */
 var utils = require('./utils');
+var ParseError = require('./ParseError');
 
 var ParseNode = function(type, val) {
     this.type = type;


### PR DESCRIPTION
This fixes a bug where `ParseError` is [used out of scope](https://github.com/tatetian/pseudocode.js/blob/dbc821353454327e4e50b8e393b53a6407c56990/src/Parser.js#L141).

