### PR TITLE
Add \INPUT & \OUTPUT (aliases to \REQUIRE & \ENSURE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ and `<function>`:
 \WHILE{<condition>}
     <block>
 \ENDWHILE
+# Or a repeat: \REPEAT <block> \UNTIL{<cond>}
+\REPEAT
+    <block>
+\UNTIL{<cond>}
 
 # A <function> can by defined by either \FUNCTION or \PROCEDURE
 # Both are exactly the same

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Commands for typesetting algorithms must be enclosed in an `algorithmic` environ
 \REQUIRE <text>
 # A postcondition is optional
 \ENSURE <text>
+# An input is optional
+\INPUT <text>
+# An output is optional
+\OUTPUT <text>
 # The body of your code is a <block>
 \STATE ...
 \end{algorithmic}

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -353,7 +353,7 @@ Parser.prototype._parseRepeat = function() {
     return repeatNode;
 };
 
-var INPUTS_OUTPUTS_COMMANDS = ['ensure', 'require'];
+var INPUTS_OUTPUTS_COMMANDS = ['ensure', 'require', 'input', 'output'];
 var STATEMENT_COMMANDS = ['state', 'print', 'return'];
 Parser.prototype._parseCommand = function(acceptCommands) {
     if (!this._lexer.accept('func', acceptCommands)) return null;

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -770,6 +770,8 @@ Renderer.prototype._buildTree = function(node) {
                 'state': '',
                 'ensure': 'Ensure: ',
                 'require': 'Require: ',
+                'input': 'Input: ',
+                'output': 'Output: ',
                 'print': 'print ',
                 'return': 'return ',
             }[cmdName];

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -736,6 +736,32 @@ Renderer.prototype._buildTree = function(node) {
                 this._typeKeyword(endLoopName);
             }
             break;
+        case 'repeat':
+            // \REPEAT
+            // ==>
+            // <p class="ps-line">
+            //     <span class="ps-keyword">repeat</span>
+            // </p>
+            this._newLine();
+            this._typeKeyword('repeat');
+
+            // block
+            var repeatBlock = node.children[0];
+            this._buildCommentsFromBlock(repeatBlock);
+            this._buildTree(repeatBlock);
+
+            if (!this._options.noEnd) {
+                // \UNTIL{<cond>}
+                // ==>
+                // <p class="ps-line">
+                //     <span class="ps-keyword">until</span>
+                // </p>
+                this._newLine();
+                this._typeKeyword('until ');
+                var repeatCond = node.children[1];
+                this._buildTree(repeatCond);
+            }
+            break;
         // ------------------- Lines -------------------
         case 'command':
             // commands: \STATE, \ENSURE, \PRINT, \RETURN, etc.

--- a/static/samples.html.template
+++ b/static/samples.html.template
@@ -84,6 +84,13 @@
                 \STATE $i \gets i + 1$
             \ENDWHILE
         \ENDPROCEDURE
+        \PROCEDURE{Test-Repeat}{$n$}
+            \STATE $i \gets 0$
+            \REPEAT
+                \PRINT $i$
+                \STATE $i \gets i + 1$
+            \UNTIL{$i>n$}
+        \ENDPROCEDURE
         \end{algorithmic}
         \end{algorithm}
         \begin{algorithm}

--- a/static/samples.html.template
+++ b/static/samples.html.template
@@ -19,6 +19,10 @@
         \begin{algorithm}
         \caption{Test text-style}
         \begin{algorithmic}
+        \REQUIRE some preconditions
+        \ENSURE some postconditions
+        \INPUT some inputs
+        \OUTPUT some outputs
         \PROCEDURE{Test-Declarations}{}
             \STATE font families: {\sffamily sffamily, \ttfamily ttfamily, \normalfont normalfont, \rmfamily rmfamily.}
             \STATE font weights: {normal weight, \bfseries bold, \mdseries 


### PR DESCRIPTION
There are many users who want `input` & `output` rather than `require` & `ensure`, including me. In standard LaTeX, you can do it by `\renewcommand`([ref](http://tipstrickshowtos.blogspot.com/2010/11/replace-require-and-ensure-with-input.html)). But here it isn't supported. So I added a few lines to support it (as just **_aliases_** to `require` & `ensure`).

Useful for me:
![image](https://user-images.githubusercontent.com/22856433/56858988-c4e7ca00-69b6-11e9-85d6-1673f7024881.png)
