### PR TITLE
Support MathJax

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Tate Tian (tatetian@gmail.com)
+Copyright (c) 2020 Saswat Padhi (saswat.sourav@gmail.com)
+Copyright (c) 2015-2019 Tate Tian (tatetian@gmail.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: default setup lint build release clean
 
-VERSION=1.1
+VERSION=2.0
 
 # Building tools
 BROWSERIFY = $(realpath ./node_modules/.bin/browserify)
@@ -12,6 +12,8 @@ UGLIFYJS = $(realpath ./node_modules/.bin/uglifyjs) \
 CLEANCSS = $(realpath ./node_modules/.bin/cleancss)
 ESLINT = $(realpath ./node_modules/.bin/eslint)
 
+SAMPLES = build/katex-samples.html build/mathjax-v2-samples.html build/mathjax-v3-samples.html
+
 default: build
 
 
@@ -21,12 +23,12 @@ setup: static/katex/
 
 static/katex/:
 	@rm -rf static/katex
-	cd static && wget https://github.com/Khan/KaTeX/releases/download/v0.8.0/katex.zip && unzip katex.zip
+	cd static && wget https://github.com/Khan/KaTeX/releases/download/v0.11.1/katex.zip && unzip katex.zip
 	@rm -rf static/katex.zip
 	@echo "> Katex downloaded"
 
 
-build: build/pseudocode.js build/pseudocode.css build/samples.html
+build: build/pseudocode.js build/pseudocode.css $(SAMPLES)
 	@echo "> Building succeeded"
 
 build/pseudocode.js: pseudocode.js $(wildcard src/*.js)
@@ -43,7 +45,7 @@ watch-js: pseudocode.js $(wildcard src/*.js)
 build/pseudocode.css: static/pseudocode.css
 	cp static/pseudocode.css build/pseudocode.css
 
-build/samples.html: static/samples.html.template
+build/%-samples.html: static/%-samples.html.template
 	cp $< $@
 
 
@@ -57,7 +59,7 @@ build/pseudocode-js.tar.gz: build/$(RELEASE_DIR)
 build/pseudocode-js.zip: build/$(RELEASE_DIR)
 	cd build && zip -rq pseudocode-js.zip $(RELEASE_DIR)
 
-build/$(RELEASE_DIR): build/pseudocode.js build/pseudocode.min.js build/pseudocode.css build/pseudocode.min.css build/samples.html README.md
+build/$(RELEASE_DIR): build/pseudocode.js build/pseudocode.min.js build/pseudocode.css build/pseudocode.min.css $(SAMPLES) README.md
 	mkdir -p build/$(RELEASE_DIR)
 	cp -r $^ build/$(RELEASE_DIR)
 

--- a/README.md
+++ b/README.md
@@ -16,51 +16,107 @@ It supports all modern browsers, including Chrome, Safari, Firefox, Edge, and
 IE 9 - IE 11.
 
 ## Demo
-Visit the [project website](http://www.tatetian.io/pseudocode.js) for demo.
+Visit the [project website](https://saswatpadhi.github.io/pseudocode.js) for demo.
 
 ## Usage
 
 ### Quick Start
-Download [pseudocode.js](https://github.com/tatetian/pseudocode.js/releases), 
-and host the files on your server. And then include the `js` and `css` files in 
-your HTML files:
+
+Pseudocode.js can render math formulas using either
+[KaTeX](https://github.com/Khan/KaTeX), or [MathJax](https://www.mathjax.org/).
+
+#### Step 1A &middot; For KaTeX users
+Include the following in the `<head>` of your page:
+
+```html
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.css"
+        integrity="sha256-V8SV2MO1FUb63Bwht5Wx9x6PVHNa02gv8BgH/uH3ung=" crossorigin="anonymous" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.js"
+        integrity="sha256-F/Xda58SPdcUCr+xhSGz9MA2zQBPb0ASEYKohl8UCHc=" crossorigin="anonymous">
+</script>
+```
+
+#### Step 1B &middot; For MathJax 2.x users
+Include the following in the `<head>` of your page:
+
+```html
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_CHTML'>
+</script>
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+        tex2jax: {
+            inlineMath: [['$','$'], ['\\(','\\)']],
+            displayMath: [['$$','$$'], ['\[','\]']],
+            processEscapes: true,
+            processEnvironments: true,
+        }
+    });
+</script>
+```
+
+#### Step 1C &middot; For MathJax 3.x users
+Include the following in the `<head>` of your page:
+
+```html
+<script>
+    MathJax = {
+        tex: {
+            inlineMath: [['$','$'], ['\\(','\\)']],
+            displayMath: [['$$','$$'], ['\[','\]']],
+            processEscapes: true,
+            processEnvironments: true,
+        }
+    }
+</script>
+<script src="https://cdn.jsdelivr.net/npm/mathjax@3.0.0/es5/tex-chtml.js"
+        integrity="sha256-3Fdoa5wQb+JYfEmTpQHx9sc/GuwpfC/0R9EpBki+mf8=" crossorigin>
+</script>
+```
+
+#### Step 2 &middot; Grab pseudocode.js
+Download a stable release of [pseudocode.js](https://github.com/SaswatPadhi/pseudocode.js/releases), 
+and host the files on your server.
+Then include the following in the `<head>` of your page:
 
 ```html
 <link rel="stylesheet" href="//path/to/pseudocode/pseudocode.min.css">
 <script src="//path/to/pseudocode/pseudocode.min.js"></script>
 ```
 
-Pseudocode.js can use either [KaTeX](https://github.com/Khan/KaTeX) or [MathJax](https://www.mathjax.org/) to render math 
-formulas and uses some KaTeX's fonts **(KaTeX's CSS)** to render styled texts.
 
-#### For KaTeX users
-Include these 2 tags in `<head>`:
-```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css" integrity="sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ" crossorigin="anonymous">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-beta/katex.min.js" integrity="sha384-ad+n9lzhJjYgO67lARKETJH6WuQVDDlRfj81AJJSswMyMkXTD49wBj5EP004WOY6" crossorigin="anonymous"></script>
+#### Step 3 &middot; Write your pseudocode inside a `<pre>`
+We assume the pseudocode to be rendered is in a `<pre>` DOM element.
+Here is an example that illustrates a quicksort algorithm:
+
+```tex
+% This quicksort algorithm is extracted from Chapter 7, Introduction to Algorithms (3rd edition)
+\begin{algorithm}
+\caption{Quicksort}
+\begin{algorithmic}
+\PROCEDURE{Quicksort}{$A, p, r$}
+    \IF{$p < r$} 
+        \STATE $q = $ \CALL{Partition}{$A, p, r$}
+        \STATE \CALL{Quicksort}{$A, p, q - 1$}
+        \STATE \CALL{Quicksort}{$A, q + 1, r$}
+    \ENDIF
+\ENDPROCEDURE
+\PROCEDURE{Partition}{$A, p, r$}
+    \STATE $x = A[r]$
+    \STATE $i = p - 1$
+    \FOR{$j = p$ \TO $r - 1$}
+        \IF{$A[j] < x$}
+            \STATE $i = i + 1$
+            \STATE exchange
+            $A[i]$ with $A[j]$
+        \ENDIF
+        \STATE exchange $A[i]$ with $A[r]$
+    \ENDFOR
+\ENDPROCEDURE
+\end{algorithmic}
+\end{algorithm}</textarea>
 ```
 
-#### For MathJax users
-Include these 3 tags in `<head>`:
-```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css" integrity="sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ" crossorigin="anonymous">
-<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML'></script>
-<script type="text/x-mathjax-config">
-    MathJax.Hub.Config({
-    jax: ["output/SVG"],
-    tex2jax: {
-        inlineMath: [['$','$'], ['\\(','\\)']],
-        displayMath: [['$$','$$'], ['\[','\]']],
-        processEscapes: true,
-        processEnvironments: true,
-        skipTags: ['code', 'script', 'noscript', 'style', 'textarea', 'pre'],
-        TeX: { equationNumbers: { autoNumber: "AMS" },
-            extensions: ["AMSmath.js", "AMSsymbols.js"] }
-    }
-    });
-</script>
-```
-
+### API
 Assume the pseudocode to be rendered is in a `<pre>` DOM element:
 ```html
 <pre id="hello-world-code" style="display:hidden;">
@@ -91,36 +147,6 @@ var htmlStr = pseudocode.renderToString(code, options);
 console.log(htmlStr);
 ```
 
-### Example
-To give you a sense of the grammar for pseudocode, here is an example that 
-illustrates a quicksort algorithm:
-```tex
-% This quicksort algorithm is extracted from Chapter 7, Introduction to Algorithms (3rd edition)
-\begin{algorithm}
-\caption{Quicksort}
-\begin{algorithmic}
-\PROCEDURE{Quicksort}{$A, p, r$}
-    \IF{$p < r$} 
-        \STATE $q = $ \CALL{Partition}{$A, p, r$}
-        \STATE \CALL{Quicksort}{$A, p, q - 1$}
-        \STATE \CALL{Quicksort}{$A, q + 1, r$}
-    \ENDIF
-\ENDPROCEDURE
-\PROCEDURE{Partition}{$A, p, r$}
-    \STATE $x = A[r]$
-    \STATE $i = p - 1$
-    \FOR{$j = p$ \TO $r - 1$}
-        \IF{$A[j] < x$}
-            \STATE $i = i + 1$
-            \STATE exchange
-            $A[i]$ with $A[j]$
-        \ENDIF
-        \STATE exchange $A[i]$ with $A[r]$
-    \ENDFOR
-\ENDPROCEDURE
-\end{algorithmic}
-\end{algorithm}</textarea>
-```
 
 ### Grammar
 There are several packages for typesetting algorithms in LaTeX, among which 
@@ -264,17 +290,21 @@ make setup
 make
 ```
 
-Then, open `static/test-suite.html` in your favourite browser to see whether 
-algorithms are typeset correctly.
+Then, open one of the sample documents:
+- `build/katex-samples.html`, or
+- `build/mathjax-v2-samples.html`, or
+- `build/mathjax-v3-samples.html`
+in your favourite browser to check if the algorithms are typeset correctly.
 
 
 ## Author
-Tate Tian ([@tatetian](https://github.com/tatetian)) creates pseudocode.js. Any 
-suggestions and bug reports are welcome.
+pseudocode.js was originally written by Tate Tian ([@tatetian](https://github.com/tatetian)).
+Together with [@ZJUGuoShuai](https://github.com/ZJUGuoShuai),
+I ([@SaswatPadhi](https://github.com/SaswatPadhi)) added the MathJax support,
+and I am the current maintainer of this project.
+Suggestions, bug reports and pull requests are most welcome.
 
 ## Acknowledgement
-Pseudocode.js is partially inspired by [KaTeX](http://khan.github.io/KaTeX/) and 
-relies on it to render math formulas.
+Pseudocode.js is partially inspired by [KaTeX](http://khan.github.io/KaTeX/).
 Thanks Emily Eisenberg([@xymostech](https://github.com/xymostech))
 and other contributers for building such a wonderful project.
-

--- a/README.md
+++ b/README.md
@@ -30,9 +30,36 @@ your HTML files:
 <script src="//path/to/pseudocode/pseudocode.min.js"></script>
 ```
 
-Pseudocode.js depends on [KaTeX](https://github.com/Khan/KaTeX) to render math 
-formulas and uses KaTeX's fonts to render texts. So make sure that [KaTeX is 
-setup](https://github.com/Khan/KaTeX#usage) properly.
+Pseudocode.js can use either [KaTeX](https://github.com/Khan/KaTeX) or [MathJax](https://www.mathjax.org/) to render math 
+formulas and uses some KaTeX's fonts **(KaTeX's CSS)** to render styled texts.
+
+#### For KaTeX users
+Include these 2 tags in `<head>`:
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css" integrity="sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ" crossorigin="anonymous">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-beta/katex.min.js" integrity="sha384-ad+n9lzhJjYgO67lARKETJH6WuQVDDlRfj81AJJSswMyMkXTD49wBj5EP004WOY6" crossorigin="anonymous"></script>
+```
+
+#### For MathJax users
+Include these 3 tags in `<head>`:
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css" integrity="sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ" crossorigin="anonymous">
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML'></script>
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+    jax: ["output/SVG"],
+    tex2jax: {
+        inlineMath: [['$','$'], ['\\(','\\)']],
+        displayMath: [['$$','$$'], ['\[','\]']],
+        processEscapes: true,
+        processEnvironments: true,
+        skipTags: ['code', 'script', 'noscript', 'style', 'textarea', 'pre'],
+        TeX: { equationNumbers: { autoNumber: "AMS" },
+            extensions: ["AMSmath.js", "AMSsymbols.js"] }
+    }
+    });
+</script>
+```
 
 Assume the pseudocode to be rendered is in a `<pre>` DOM element:
 ```html

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
     "name": "pseudocode",
-    "version": "1.1.1",
+    "version": "2.0",
     "author": {
-        "name": "Tate Tian",
-        "email": "tatetian@gmail.com",
-        "url": "http://www.tatetian.me"
+        "name": "Saswat Padhi",
+        "email": "saswat.sourav@gmail.com",
+        "url": "https://saswatpadhi.github.io/"
     },
     "description": "Beautiful pseudocode for the Web",
     "main": "pseudocode.js",
     "repository": {
         "type": "git",
-        "url": "git://github.com/tatetian/pseudocode.js"
+        "url": "git://github.com/SaswatPadhi/pseudocode.js"
     },
     "files": [
-        "PseudoCode.js",
+        "pseudoCode.js",
         "src/"
     ],
     "devDependencies": {

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -3,7 +3,7 @@
 var utils = require('./utils');
 
 /*
- * TextStyle - used by TextEnvironment class to  handles LaTeX text-style
+ * TextStyle - used by TextEnvironment class to handle LaTeX text-style
  * commands or declarations.
  *
  * The font declarations are:
@@ -141,7 +141,7 @@ TextEnvironment.prototype._renderCloseText = function(node) {
     var newTextStyle = new TextStyle(this._textStyle.fontSize());
     var closeTextEnv = new TextEnvironment(node.children, newTextStyle);
     if (node.whitespace) this._html.putText(' ');
-    this._html.putSpan(closeTextEnv.renderToHTML());
+    this._html.putHTML(closeTextEnv.renderToHTML());
 };
 
 TextEnvironment.prototype.renderToHTML = function() {
@@ -171,16 +171,11 @@ TextEnvironment.prototype.renderToHTML = function() {
                     }
                 }
 
-                // KaTeX
-                if (useKatex) {
-                    var mathHTML = katex.renderToString(text);
-                    this._html.putSpan(mathHTML);
+                if (useKatex) { // KaTeX
+                    this._html.putHTML(katex.renderToString(text));
                 }
-
-                // MathJax
-                else {
-                    this._html.putSpan(MathJax.HTML.Element("span", null,
-                        ["$" + text + "$"]).outerHTML);
+                else { // MathJax
+                    this._html.putText("$" + text + "$");
                 }
 
                 break;
@@ -261,7 +256,7 @@ TextEnvironment.prototype.renderToHTML = function() {
                 this._html.beginSpan(null, this._textStyle.toCSS());
                 var textEnvForDclr = new TextEnvironment(this._nodes,
                                                          this._textStyle);
-                this._html.putSpan(textEnvForDclr.renderToHTML());
+                this._html.putHTML(textEnvForDclr.renderToHTML());
                 this._html.endSpan();
                 break;
             case 'font-cmd':
@@ -273,7 +268,7 @@ TextEnvironment.prototype.renderToHTML = function() {
                 this._html.beginSpan(null, innerTextStyle.toCSS());
                 var textEnvForCmd = new TextEnvironment(textNode.children,
                                                         innerTextStyle);
-                this._html.putSpan(textEnvForCmd.renderToHTML());
+                this._html.putHTML(textEnvForCmd.renderToHTML());
                 this._html.endSpan();
                 break;
             default:
@@ -325,8 +320,7 @@ HTMLBuilder.prototype.endSpan = function() {
     return this._endTag('span');
 };
 
-HTMLBuilder.prototype.putHTML =
-HTMLBuilder.prototype.putSpan = function(html) {
+HTMLBuilder.prototype.putHTML = function(html) {
     this._flushText();
     this._body.push(html);
     return this;
@@ -816,13 +810,13 @@ Renderer.prototype._buildTree = function(node) {
         case 'open-text':
             var openTextEnv = new TextEnvironment(node.children,
                                                   this._globalTextStyle);
-            this._html.putSpan(openTextEnv.renderToHTML());
+            this._html.putHTML(openTextEnv.renderToHTML());
             break;
         case 'close-text':
             var outerFontSize = this._globalTextStyle.fontSize();
             var newTextStyle = new TextStyle(outerFontSize);
             var closeTextEnv = new TextEnvironment(node.children, newTextStyle);
-            this._html.putSpan(closeTextEnv.renderToHTML());
+            this._html.putHTML(closeTextEnv.renderToHTML());
             break;
         default:
             throw new ParseError('Unexpected ParseNode of type ' + node.type);

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -160,12 +160,29 @@ TextEnvironment.prototype.renderToHTML = function() {
                 this._html.putText(text);
                 break;
             case 'math':
-                if (!katex) {
+                useKatex = true;
+                if (typeof katex === 'undefined') {
                     try { katex = require('katex'); }
-                    catch (e) { throw 'katex is required to render math'; }
+                    catch (e) {
+                        if (typeof MathJax === 'undefined') {
+                            throw 'KaTeX or MathJax is required to render math';
+                        }
+                        var useKatex = false;
+                    }
                 }
-                var mathHTML = katex.renderToString(text);
-                this._html.putSpan(mathHTML);
+
+                // KaTeX
+                if (useKatex) {
+                    var mathHTML = katex.renderToString(text);
+                    this._html.putSpan(mathHTML);
+                }
+
+                // MathJax
+                else {
+                    this._html.putSpan(MathJax.HTML.Element("span", null,
+                        ["$" + text + "$"]).outerHTML);
+                }
+
                 break;
             case 'cond-symbol':
                 this._html

--- a/static/katex-samples.html.template
+++ b/static/katex-samples.html.template
@@ -3,35 +3,14 @@
 
 <head>
     <meta charset="utf-8">
-    <title>Pseudocode.js Samples</title>
+    <title>Pseudocode.js Samples with KaTeX</title>
 
-    <!-- KaTeX is the only dependency -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css" integrity="sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ" crossorigin="anonymous">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-beta/katex.min.js" integrity="sha384-ad+n9lzhJjYgO67lARKETJH6WuQVDDlRfj81AJJSswMyMkXTD49wBj5EP004WOY6" crossorigin="anonymous"></script>
-
-    <!-- Or use a loca copy of KaTeX
-    <link rel="stylesheet" href="./katex/katex.min.css" type="text/css">
-    <script src="./katex/katex.min.js" type="text/javascript"></script>
-    -->
-
-    <!-- Or use MathJax
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css" integrity="sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ" crossorigin="anonymous">
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML'></script>
-    <script type="text/x-mathjax-config">
-        MathJax.Hub.Config({
-        jax: ["output/SVG"],
-        tex2jax: {
-            inlineMath: [['$','$'], ['\\(','\\)']],
-            displayMath: [['$$','$$'], ['\[','\]']],
-            processEscapes: true,
-            processEnvironments: true,
-            skipTags: ['code', 'script', 'noscript', 'style', 'textarea', 'pre'],
-            TeX: { equationNumbers: { autoNumber: "AMS" },
-                extensions: ["AMSmath.js", "AMSsymbols.js"] }
-        }
-        });
+    <!-- Setup KaTeX -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.css"
+          integrity="sha256-V8SV2MO1FUb63Bwht5Wx9x6PVHNa02gv8BgH/uH3ung=" crossorigin="anonymous" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.js"
+          integrity="sha256-F/Xda58SPdcUCr+xhSGz9MA2zQBPb0ASEYKohl8UCHc=" crossorigin="anonymous">
     </script>
-    -->
 
     <!-- Pseudocode -->
     <link rel="stylesheet" href="pseudocode.css" type="text/css">
@@ -52,7 +31,7 @@
             \STATE font weights: {normal weight, \bfseries bold, \mdseries 
             medium, \lfseries lighter. }
             \STATE font shapes: {\itshape itshape \scshape Small-Caps \slshape slshape \upshape upshape.}
-            \STATE font sizings:  \tiny tiny \scriptsize scriptsize \footnotesize
+            \STATE font sizes: \tiny tiny \scriptsize scriptsize \footnotesize
             footnotesize \small small \normalsize normal \large large \Large Large
             \LARGE LARGE \huge huge \Huge Huge \normalsize
         \ENDPROCEDURE
@@ -162,7 +141,7 @@
                 \IF{$A[j] < x$}
                     \STATE $i = i + 1$
                     \STATE exchange
-                    $A[i]$ with     $A[j]$
+                    $A[i]$ with $A[j]$
                 \ENDIF
                 \STATE exchange $A[i]$ with $A[r]$
             \ENDFOR
@@ -174,6 +153,7 @@
         var testBasics = document.getElementById("test-basics").textContent;
         pseudocode.render(testBasics, document.body, {
             lineNumber: false,
+            noEnd: true
         });
         var testCodes = document.getElementById("test-codes").textContent;
         pseudocode.render(testCodes, document.body, {
@@ -187,5 +167,4 @@
         });
     </script>
 </body>
-
 </html>

--- a/static/mathjax-v2-samples.html.template
+++ b/static/mathjax-v2-samples.html.template
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Pseudocode.js Samples with MathJax</title>
+
+    <!-- Setup MathJax -->
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_CHTML'>
+    </script>
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+            tex2jax: {
+                inlineMath: [['$','$'], ['\\(','\\)']],
+                displayMath: [['$$','$$'], ['\[','\]']],
+                processEscapes: true,
+                processEnvironments: true,
+                skipTags: ['code', 'script', 'noscript', 'style', 'textarea', 'pre'],
+            }
+        });
+    </script>
+
+    <!-- Pseudocode -->
+    <link rel="stylesheet" href="pseudocode.css" type="text/css">
+    <script src="pseudocode.js" type="text/javascript"></script>
+</head>
+
+<body>
+    <pre id="test-basics" style="display:none">
+        \begin{algorithm}
+        \caption{Test text-style}
+        \begin{algorithmic}
+        \REQUIRE some preconditions
+        \ENSURE some postconditions
+        \INPUT some inputs
+        \OUTPUT some outputs
+        \PROCEDURE{Test-Declarations}{}
+            \STATE font families: {\sffamily sffamily, \ttfamily ttfamily, \normalfont normalfont, \rmfamily rmfamily.}
+            \STATE font weights: {normal weight, \bfseries bold, \mdseries 
+            medium, \lfseries lighter. }
+            \STATE font shapes: {\itshape itshape \scshape Small-Caps \slshape slshape \upshape upshape.}
+            \STATE font sizes: \tiny tiny \scriptsize scriptsize \footnotesize
+            footnotesize \small small \normalsize normal \large large \Large Large
+            \LARGE LARGE \huge huge \Huge Huge \normalsize
+        \ENDPROCEDURE
+        \PROCEDURE{Test-Commands}{}
+            \STATE \textnormal{textnormal,} \textrm{textrm,} \textsf{textsf,} \texttt{texttt.}
+            \STATE \textbf{textbf,} \textmd{textmd,} \textlf{textlf.}
+            \STATE \textup{textup,} \textit{textit,} \textsc{textsc,} \textsl{textsl.}
+            \STATE \uppercase{uppercase,} \lowercase{LOWERCASE.}
+        \ENDPROCEDURE
+        \PROCEDURE{Test-Colors}{}
+        % feature not implemented
+        \ENDPROCEDURE
+        \end{algorithmic}
+        \end{algorithm}
+
+        \begin{algorithm}
+        \caption{Test atoms}
+        \begin{algorithmic}
+        \STATE \textbf{Specials:} \{ \} \$ \& \# \% \_
+        \STATE \textbf{Bools:} \AND \OR \NOT \TRUE \FALSE
+        \STATE \textbf{Carriage return:} first line \\ second line
+        \STATE \textbf{Text-symbols:} \textbackslash
+        \STATE \textbf{Quote-symbols:} `single quotes', ``double quotes''
+        \STATE \textbf{Math:} $(\mathcal{C}_m)$, $i \gets i + 1$, $E=mc^2$, \( x^n + y^n = z^n \), $\$$, \(\$\)
+        \END{ALGORITHMIC}
+        \END{ALGORITHM}
+    </pre>
+    <pre id="test-codes" style="display:none">
+        \begin{algorithm}
+        \caption{Test control blocks}
+        \begin{algorithmic}
+        \PROCEDURE{Test-If}{}
+            \IF{&lt;cond&gt;}
+                \STATE &lt;block&gt;
+            \ELIF{&lt;cond&gt;}
+                \STATE &lt;block&gt;
+            \ELSE
+                \STATE &lt;block&gt;
+            \ENDIF
+        \ENDPROCEDURE
+        \PROCEDURE{Test-For}{$n$}
+            \STATE $i \gets 0$
+            \FOR{$i < n$}
+                \PRINT $i$
+                \STATE $i \gets i + 1$
+            \ENDFOR
+        \ENDPROCEDURE
+        \PROCEDURE{Test-For-All}{$n$}
+            \FORALL{$i \in \{0, 1, \cdots, n\}$}
+                \PRINT $i$
+            \ENDFOR
+        \ENDPROCEDURE
+        \PROCEDURE{Test-While}{$n$}
+            \STATE $i \gets 0$
+            \WHILE{$i < n$}
+                \PRINT $i$
+                \STATE $i \gets i + 1$
+            \ENDWHILE
+        \ENDPROCEDURE
+        \PROCEDURE{Test-Repeat}{$n$}
+            \STATE $i \gets 0$
+            \REPEAT
+                \PRINT $i$
+                \STATE $i \gets i + 1$
+            \UNTIL{$i>n$}
+        \ENDPROCEDURE
+        \end{algorithmic}
+        \end{algorithm}
+        \begin{algorithm}
+        \caption{Test statements and comments}
+        \begin{algorithmic}
+        \PROCEDURE{Test-Statements}{}
+            \STATE This line is a normal statement
+            \PRINT \texttt{`this is print statement'}
+            \RETURN $retval$
+        \ENDPROCEDURE
+
+        \PROCEDURE{Test-Comments}{} \COMMENT{comment for procedure}
+            \STATE a statement \COMMENT{inline comment}
+            \STATE \COMMENT{line comment}
+            \IF{some condition}\COMMENT{comment for if}
+                \RETURN \TRUE \COMMENT{another inline comment}
+            \ELSE \COMMENT{comment for else}
+                \RETURN \FALSE \COMMENT{yet another inline comment}
+            \ENDIF
+        \ENDPROCEDURE
+        \end{algorithmic}
+        \end{algorithm}
+    </pre>
+    <pre id="test-examples" style="display:none">
+        % This quicksort algorithm is extracted from Chapter 7, Introduction 
+        % to Algorithms (3rd edition)
+        \begin{algorithm}
+        \caption{Quicksort}
+        \begin{algorithmic}
+        \PROCEDURE{Quicksort}{$A, p, r$}
+            \IF{$p < r$} 
+                \STATE $q = $ \CALL{Partition}{$A, p, r$}
+                \STATE \CALL{Quicksort}{$A, p, q - 1$}
+                \STATE \CALL{Quicksort}{$A, q + 1, r$}
+            \ENDIF
+        \ENDPROCEDURE
+        \PROCEDURE{Partition}{$A, p, r$}
+            \STATE $x = A[r]$
+            \STATE $i = p - 1$
+            \FOR{$j = p$ \TO $r - 1$}
+                \IF{$A[j] < x$}
+                    \STATE $i = i + 1$
+                    \STATE exchange
+                    $A[i]$ with $A[j]$
+                \ENDIF
+                \STATE exchange $A[i]$ with $A[r]$
+            \ENDFOR
+        \ENDPROCEDURE
+        \end{algorithmic}
+        \end{algorithm}
+    </pre>
+    <script type="text/javascript">
+        var testBasics = document.getElementById("test-basics").textContent;
+        pseudocode.render(testBasics, document.body, {
+            lineNumber: false,
+            noEnd: true
+        });
+        var testCodes = document.getElementById("test-codes").textContent;
+        pseudocode.render(testCodes, document.body, {
+            lineNumber: false,
+            noEnd: false
+        });
+        var testExamples = document.getElementById("test-examples").textContent;
+        pseudocode.render(testExamples, document.body, {
+            lineNumber: true,
+            noEnd: false
+        });
+    </script>
+</body>
+</html>

--- a/static/mathjax-v3-samples.html.template
+++ b/static/mathjax-v3-samples.html.template
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Pseudocode.js Samples with MathJax</title>
+
+    <!-- Setup MathJax -->
+    <script>
+        MathJax = {
+            tex: {
+                inlineMath: [['$','$'], ['\\(','\\)']],
+                displayMath: [['$$','$$'], ['\[','\]']],
+                processEscapes: true,
+                processEnvironments: true,
+            }
+        }
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3.0.0/es5/tex-chtml.js"
+            integrity="sha256-3Fdoa5wQb+JYfEmTpQHx9sc/GuwpfC/0R9EpBki+mf8=" crossorigin>
+    </script>
+
+    <!-- Pseudocode -->
+    <link rel="stylesheet" href="pseudocode.css" type="text/css">
+    <script src="pseudocode.js" type="text/javascript"></script>
+</head>
+
+<body>
+    <pre id="test-basics" style="display:none">
+        \begin{algorithm}
+        \caption{Test text-style}
+        \begin{algorithmic}
+        \REQUIRE some preconditions
+        \ENSURE some postconditions
+        \INPUT some inputs
+        \OUTPUT some outputs
+        \PROCEDURE{Test-Declarations}{}
+            \STATE font families: {\sffamily sffamily, \ttfamily ttfamily, \normalfont normalfont, \rmfamily rmfamily.}
+            \STATE font weights: {normal weight, \bfseries bold, \mdseries 
+            medium, \lfseries lighter. }
+            \STATE font shapes: {\itshape itshape \scshape Small-Caps \slshape slshape \upshape upshape.}
+            \STATE font sizes: \tiny tiny \scriptsize scriptsize \footnotesize
+            footnotesize \small small \normalsize normal \large large \Large Large
+            \LARGE LARGE \huge huge \Huge Huge \normalsize
+        \ENDPROCEDURE
+        \PROCEDURE{Test-Commands}{}
+            \STATE \textnormal{textnormal,} \textrm{textrm,} \textsf{textsf,} \texttt{texttt.}
+            \STATE \textbf{textbf,} \textmd{textmd,} \textlf{textlf.}
+            \STATE \textup{textup,} \textit{textit,} \textsc{textsc,} \textsl{textsl.}
+            \STATE \uppercase{uppercase,} \lowercase{LOWERCASE.}
+        \ENDPROCEDURE
+        \PROCEDURE{Test-Colors}{}
+        % feature not implemented
+        \ENDPROCEDURE
+        \end{algorithmic}
+        \end{algorithm}
+
+        \begin{algorithm}
+        \caption{Test atoms}
+        \begin{algorithmic}
+        \STATE \textbf{Specials:} \{ \} \$ \& \# \% \_
+        \STATE \textbf{Bools:} \AND \OR \NOT \TRUE \FALSE
+        \STATE \textbf{Carriage return:} first line \\ second line
+        \STATE \textbf{Text-symbols:} \textbackslash
+        \STATE \textbf{Quote-symbols:} `single quotes', ``double quotes''
+        \STATE \textbf{Math:} $(\mathcal{C}_m)$, $i \gets i + 1$, $E=mc^2$, \( x^n + y^n = z^n \), $\$$, \(\$\)
+        \END{ALGORITHMIC}
+        \END{ALGORITHM}
+    </pre>
+    <pre id="test-codes" style="display:none">
+        \begin{algorithm}
+        \caption{Test control blocks}
+        \begin{algorithmic}
+        \PROCEDURE{Test-If}{}
+            \IF{&lt;cond&gt;}
+                \STATE &lt;block&gt;
+            \ELIF{&lt;cond&gt;}
+                \STATE &lt;block&gt;
+            \ELSE
+                \STATE &lt;block&gt;
+            \ENDIF
+        \ENDPROCEDURE
+        \PROCEDURE{Test-For}{$n$}
+            \STATE $i \gets 0$
+            \FOR{$i < n$}
+                \PRINT $i$
+                \STATE $i \gets i + 1$
+            \ENDFOR
+        \ENDPROCEDURE
+        \PROCEDURE{Test-For-All}{$n$}
+            \FORALL{$i \in \{0, 1, \cdots, n\}$}
+                \PRINT $i$
+            \ENDFOR
+        \ENDPROCEDURE
+        \PROCEDURE{Test-While}{$n$}
+            \STATE $i \gets 0$
+            \WHILE{$i < n$}
+                \PRINT $i$
+                \STATE $i \gets i + 1$
+            \ENDWHILE
+        \ENDPROCEDURE
+        \PROCEDURE{Test-Repeat}{$n$}
+            \STATE $i \gets 0$
+            \REPEAT
+                \PRINT $i$
+                \STATE $i \gets i + 1$
+            \UNTIL{$i>n$}
+        \ENDPROCEDURE
+        \end{algorithmic}
+        \end{algorithm}
+        \begin{algorithm}
+        \caption{Test statements and comments}
+        \begin{algorithmic}
+        \PROCEDURE{Test-Statements}{}
+            \STATE This line is a normal statement
+            \PRINT \texttt{`this is print statement'}
+            \RETURN $retval$
+        \ENDPROCEDURE
+
+        \PROCEDURE{Test-Comments}{} \COMMENT{comment for procedure}
+            \STATE a statement \COMMENT{inline comment}
+            \STATE \COMMENT{line comment}
+            \IF{some condition}\COMMENT{comment for if}
+                \RETURN \TRUE \COMMENT{another inline comment}
+            \ELSE \COMMENT{comment for else}
+                \RETURN \FALSE \COMMENT{yet another inline comment}
+            \ENDIF
+        \ENDPROCEDURE
+        \end{algorithmic}
+        \end{algorithm}
+    </pre>
+    <pre id="test-examples" style="display:none">
+        % This quicksort algorithm is extracted from Chapter 7, Introduction 
+        % to Algorithms (3rd edition)
+        \begin{algorithm}
+        \caption{Quicksort}
+        \begin{algorithmic}
+        \PROCEDURE{Quicksort}{$A, p, r$}
+            \IF{$p < r$} 
+                \STATE $q = $ \CALL{Partition}{$A, p, r$}
+                \STATE \CALL{Quicksort}{$A, p, q - 1$}
+                \STATE \CALL{Quicksort}{$A, q + 1, r$}
+            \ENDIF
+        \ENDPROCEDURE
+        \PROCEDURE{Partition}{$A, p, r$}
+            \STATE $x = A[r]$
+            \STATE $i = p - 1$
+            \FOR{$j = p$ \TO $r - 1$}
+                \IF{$A[j] < x$}
+                    \STATE $i = i + 1$
+                    \STATE exchange
+                    $A[i]$ with $A[j]$
+                \ENDIF
+                \STATE exchange $A[i]$ with $A[r]$
+            \ENDFOR
+        \ENDPROCEDURE
+        \end{algorithmic}
+        \end{algorithm}
+    </pre>
+    <script type="text/javascript">
+        var testBasics = document.getElementById("test-basics").textContent;
+        pseudocode.render(testBasics, document.body, {
+            lineNumber: false,
+            noEnd: true
+        });
+        var testCodes = document.getElementById("test-codes").textContent;
+        pseudocode.render(testCodes, document.body, {
+            lineNumber: false,
+            noEnd: false
+        });
+        var testExamples = document.getElementById("test-examples").textContent;
+        pseudocode.render(testExamples, document.body, {
+            lineNumber: true,
+            noEnd: false
+        });
+    </script>
+</body>
+</html>

--- a/static/pseudocode.css
+++ b/static/pseudocode.css
@@ -1,17 +1,25 @@
+@import url('https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css');
 
-@font-face{
-    font-family:KaTeX_Typewriter_Replace;
-    src:url(fonts/KaTeX_Typewriter-Regular.eot);
-    src:url(fonts/KaTeX_Typewriter-Regular.eot#iefix) format('embedded-opentype'),url(fonts/KaTeX_Typewriter-Regular.woff2) format('woff2'),url(fonts/KaTeX_Typewriter-Regular.woff) format('woff'),url(fonts/KaTeX_Typewriter-Regular.ttf) format('ttf');
-    font-weight:400;font-style:normal
+@font-face {
+    font-family: KaTeX_Typewriter_Replace;
+    src: url(fonts/KaTeX_Typewriter-Regular.eot);
+    src: url(fonts/KaTeX_Typewriter-Regular.eot#iefix) format('embedded-opentype'),
+         url(fonts/KaTeX_Typewriter-Regular.woff2) format('woff2'),
+         url(fonts/KaTeX_Typewriter-Regular.woff) format('woff'),
+         url(fonts/KaTeX_Typewriter-Regular.ttf) format('ttf');
+    font-weight: 400;
+    font-style: normal;
 }
 
-@font-face{
-    font-family:KaTeX_SansSerif_Replace;
-    src:url(fonts/KaTeX_SansSerif-Bold.eot);
-    src:url(fonts/KaTeX_SansSerif-Bold.eot#iefix) format('embedded-opentype'),url(fonts/KaTeX_SansSerif-Bold.woff2) format('woff2'),url(fonts/KaTeX_SansSerif-Bold.woff) format('woff'),url(fonts/KaTeX_SansSerif-Bold.ttf) format('ttf');
-    font-weight:700;
-    font-style:normal
+@font-face {
+    font-family: KaTeX_SansSerif_Replace;
+    src: url(fonts/KaTeX_SansSerif-Bold.eot);
+    src: url(fonts/KaTeX_SansSerif-Bold.eot#iefix) format('embedded-opentype'),
+         url(fonts/KaTeX_SansSerif-Bold.woff2) format('woff2'),
+         url(fonts/KaTeX_SansSerif-Bold.woff) format('woff'),
+         url(fonts/KaTeX_SansSerif-Bold.ttf) format('ttf');
+    font-weight: 700;
+    font-style: normal;
 }
 
 .ps-root {
@@ -29,10 +37,16 @@
 .ps-root .ps-algorithm.with-caption > .ps-line:first-child {
     border-bottom: 2px solid black;
 }
+
 .ps-root .katex {
     text-indent: 0;
     font-size: 1em;
 }
+.ps-root .mjx-chtml {
+    text-indent: 0;
+    font-size: 1em !important;
+}
+
 .ps-root .ps-line {
     margin: 0; padding: 0;
     line-height: 1.2;

--- a/static/samples.html.template
+++ b/static/samples.html.template
@@ -1,19 +1,43 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="utf-8">
     <title>Pseudocode.js Samples</title>
+
     <!-- KaTeX is the only dependency -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-beta/katex.min.css" integrity="sha384-L/SNYu0HM7XECWBeshTGLluQO9uVI1tvkCtunuoUbCHHoTH76cDyXty69Bb9I0qZ" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css" integrity="sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ" crossorigin="anonymous">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-beta/katex.min.js" integrity="sha384-ad+n9lzhJjYgO67lARKETJH6WuQVDDlRfj81AJJSswMyMkXTD49wBj5EP004WOY6" crossorigin="anonymous"></script>
+
     <!-- Or use a loca copy of KaTeX
     <link rel="stylesheet" href="./katex/katex.min.css" type="text/css">
     <script src="./katex/katex.min.js" type="text/javascript"></script>
     -->
+
+    <!-- Or use MathJax
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css" integrity="sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ" crossorigin="anonymous">
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML'></script>
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+        jax: ["output/SVG"],
+        tex2jax: {
+            inlineMath: [['$','$'], ['\\(','\\)']],
+            displayMath: [['$$','$$'], ['\[','\]']],
+            processEscapes: true,
+            processEnvironments: true,
+            skipTags: ['code', 'script', 'noscript', 'style', 'textarea', 'pre'],
+            TeX: { equationNumbers: { autoNumber: "AMS" },
+                extensions: ["AMSmath.js", "AMSsymbols.js"] }
+        }
+        });
+    </script>
+    -->
+
     <!-- Pseudocode -->
     <link rel="stylesheet" href="pseudocode.css" type="text/css">
     <script src="pseudocode.js" type="text/javascript"></script>
 </head>
+
 <body>
     <pre id="test-basics" style="display:none">
         \begin{algorithm}
@@ -163,4 +187,5 @@
         });
     </script>
 </body>
+
 </html>


### PR DESCRIPTION
By default, the code tries to use KaTeX. If it is not available, it switches to MathJax.

I tested the code and used it in my blog:

![image](https://user-images.githubusercontent.com/22856433/56877591-ba463700-6a81-11e9-9bf6-19fa5abd4484.png)

![image](https://user-images.githubusercontent.com/22856433/56877609-ce8a3400-6a81-11e9-9525-58b485d2bd6d.png)
