### PR TITLE
Fix missing commas in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ To display the caption of an algorithm, use `algorithm` environment as a 'float'
 such as
 
 ```js
-pseudocode.renderElement(document.getElementById("quicksort").
+pseudocode.renderElement(document.getElementById("quicksort"),
                          { lineNumber: true });
 ```
 
@@ -256,7 +256,7 @@ The default values of these options are:
 ```js
 var DEFAULT_OPTIONS = {
     indentSize: '1.2em',
-    commentDelimiter: '//'
+    commentDelimiter: '//',
     lineNumber: false,
     lineNumberPunc: ':',
     noEnd: false,


### PR DESCRIPTION
This PR fixes two syntax errors in README.md related to missing commas.